### PR TITLE
Update to new 'appc' cli for installing Ti SDKs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -43,14 +43,15 @@ brew update
 brew install jq # process JSON 
 
 sudo npm install -g titanium
+sudo npm install -g node-appc
 titanium login travisci@appcelerator.com travisci
-titanium sdk install latest --no-progress-bars
+appc ti sdk install latest --no-progress-bars
 
 # Android SDK seems to require newer version of SDK		
 echo
 echo "Installing $TITANIUM_SDK_VERSION"		
 echo
-titanium sdk install -d $TITANIUM_SDK_VERSION --no-progress-bars		
+appc ti sdk install -d $TITANIUM_SDK_VERSION --no-progress-bars		
 
 export TITANIUM_ROOT=`ti sdk list -o json | jq -r '.defaultInstallLocation'`
 export TITANIUM_SDK=`ti sdk list -o json | jq -r '.installed[.activeSDK]'`


### PR DESCRIPTION
The `titanium` cli doesn't receive updated SDKs anymore and is not aware of any SDKs after 4.0.0.  Using the new `appc` cli allows for the install to retrieve newer versions of the SDK.  The update also includes installing the `appc` cli from npm.